### PR TITLE
feat: add floating WhatsApp button and desktop gallery

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,6 +20,19 @@ const today = new Date();
                 </a>
         </div>
 </footer>
+<a
+  href="https://wa.me/6285780199904?text=Salam%20saya%20ingin%20berkonsultasi%20mengenai%20Alat%20kesehatan%20yang%20di%20jual%20di%20alkesduaputry.com"
+  class="whatsapp-float"
+  target="_blank"
+  rel="noopener noreferrer"
+>
+  <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fill="#25D366"
+      d="M20.52 3.48a11.86 11.86 0 00-18.2 14.3L1 23l5.4-1.24a11.86 11.86 0 005.7 1.46h.01A11.86 11.86 0 0020.52 3.48zm-8.07 17.1h-.01c-1.8 0-3.53-.48-5.05-1.39l-.36-.22-3.2.74.68-3.12-.23-.38a9.86 9.86 0 011.51-12.16 9.86 9.86 0 0116 7.25 9.86 9.86 0 01-9.35 9.28zm5.48-7.36c-.3-.15-1.77-.87-2.05-.97-.27-.1-.47-.15-.67.15-.2.3-.77.97-.95 1.17-.17.2-.35.22-.64.07-.3-.15-1.25-.46-2.38-1.47-.88-.78-1.47-1.74-1.64-2.03-.17-.3-.02-.46.13-.61.13-.13.3-.35.45-.52.15-.17.2-.3.3-.5.1-.2.05-.37-.02-.52-.08-.15-.67-1.62-.92-2.22-.24-.58-.48-.5-.67-.5-.17 0-.37-.02-.57-.02-.2 0-.52.08-.8.37-.27.3-1.05 1.02-1.05 2.48 0 1.45 1.08 2.85 1.24 3.05.15.2 2.13 3.25 5.17 4.55.72.31 1.28.5 1.72.64.72.23 1.38.2 1.9.12.58-.09 1.77-.72 2.02-1.42.25-.7.25-1.3.17-1.42-.07-.12-.27-.2-.57-.35z"
+    />
+  </svg>
+</a>
 <style>
         footer {
                 padding: 2em 1em 6em 1em;
@@ -42,6 +55,28 @@ const today = new Date();
         }
         .social-links a:hover {
                 color: rgb(var(--gray-dark));
+        }
+        .whatsapp-float {
+                position: fixed;
+                bottom: 1.5em;
+                right: 1.5em;
+                width: 60px;
+                height: 60px;
+                border-radius: 50%;
+                background-color: #25D366;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+                z-index: 1000;
+        }
+        .whatsapp-float svg {
+                fill: #fff;
+        }
+        @media (min-width: 768px) {
+                .whatsapp-float {
+                        display: none;
+                }
         }
 </style>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -104,6 +104,26 @@ const images = [
   .next {
     right: 0.5em;
   }
+
+  @media (min-width: 768px) {
+    .slider-container {
+      overflow: visible;
+    }
+    .slider {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 0.5em;
+      overflow: visible;
+      scroll-snap-type: none;
+    }
+    .slide {
+      flex: none;
+    }
+    .prev,
+    .next {
+      display: none;
+    }
+  }
 </style>
 
 <script is:inline>


### PR DESCRIPTION
## Summary
- add floating WhatsApp button for mobile users
- show gallery layout for desktop while keeping slider on mobile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68a74bdc68508326b64280d6c2eb858f