### PR TITLE
Update favicon and social metadata

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,20 +4,33 @@
 import '../styles/global.css';
 
 interface Props {
-	title: string;
-	description: string;
-	image?: string;
+        title: string;
+        description: string;
+        image?: string;
 }
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const { title, description, image = 'https://files.alkesduaputry.com/icon%20alkesduaputry.png' } = Astro.props;
 
-const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const resolvedImage = image.startsWith('http')
+        ? image
+        : new URL(image, Astro.site).toString();
 ---
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link
+        rel="icon"
+        type="image/png"
+        sizes="512x512"
+        href="https://files.alkesduaputry.com/icon%20alkesduaputry.png"
+/>
+<link
+        rel="apple-touch-icon"
+        sizes="512x512"
+        href="https://files.alkesduaputry.com/icon%20alkesduaputry.png"
+/>
 <meta name="generator" content={Astro.generator} />
 
 <!-- Font preloads -->
@@ -31,3 +44,18 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={resolvedImage} />
+<meta property="og:image:alt" content={`${title} logo`} />
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={resolvedImage} />
+<meta name="twitter:image:alt" content={`${title} logo`} />


### PR DESCRIPTION
## Summary
- point the favicon and touch icon tags to the new Alkes Duaputry logo asset
- default page imagery to the new logo so social previews pick it up
- add Open Graph and Twitter metadata so link shares include the logo image alongside title and description

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27bde74e883269f0881492d17e7e2